### PR TITLE
Update color value restrictions

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,13 +14,13 @@ module.exports = {
     "value-no-vendor-prefix": true,
     "declaration-property-value-whitelist": {
       "/color$/": [
-        "/^\\$|initial|inherit|transparent|currentColor|gray|hwb|rgba|hsl|var/"
+        "/^\\$|initial|inherit|transparent|currentColor|var/"
       ],
       "fill": [
-        "/^\\$|initial|inherit|transparent|currentColor|gray|hwb|rgba|hsl|var/"
+        "/^\\$|initial|inherit|transparent|currentColor|var/"
       ],
       "stroke": [
-        "/^\\$|initial|inherit|transparent|currentColor|gray|hwb|rgba|hsl|var/"
+        "/^\\$|initial|inherit|transparent|currentColor|var/"
       ]
     }
   }


### PR DESCRIPTION
I’m wondering if this restriction is useful: https://github.com/acolorbright/stylelint-config-acb/blob/master/index.js#L16-L24

Normally our colors would be declared as a custom property which then in turn allows any kind of color value. For instance on the acb-website we have `--color-white: #fff;` (which is allowed as we use it as `var(--color-white);`) but we can’t directly use `color: #fff;` which will result in an error because the rule doesn’t allow for hex colors to be used.